### PR TITLE
Kata/pillars

### DIFF
--- a/src/countCodeLines.js
+++ b/src/countCodeLines.js
@@ -1,0 +1,3 @@
+export const countCodeLines = () => {
+  // TO IMPLEMENT IN ANOTHER PR
+};

--- a/src/countCodeLines.test.js
+++ b/src/countCodeLines.test.js
@@ -1,0 +1,37 @@
+import { countCodeLines } from './countCodeLines';
+
+/*
+  Write a utility that counts the number of lines of actual code in a javascript source string, excluding comments and whitespace
+  The function accepts a multiline string, and returns an integer
+*/
+
+describe('countCodeLines', () => {
+  it('counts the lines containing code in a simple snippet', () => {
+    const simpleSnippet = `
+    // this snippet contains 3 lines of code
+    const darthVader = () => {
+
+      return 'The Force is strong with this one.'
+    }
+    `
+    expect(countCodeLines(simpleSnippet)).toEqual(3)
+  });
+
+  const messedUpSnippet = `
+    const subject = 'Luke'
+
+    /*****
+    * This is a snippet with 4 lines of code
+    *  \/* no nesting allowed!
+    //*****//***/// Slightly pathological comment ending...
+
+    let familyRelation = subject => (
+      subject + ' i am you father'
+    )
+
+    console.log(familyRelation(subject))
+  `
+  it('counts the lines containing code in a messed up snippet', () => {
+    expect(countCodeLines).toEqual(5)
+  });
+})

--- a/src/pillars.js
+++ b/src/pillars.js
@@ -1,3 +1,6 @@
-function pillars(num_pill, dist, width) {
-  // your code here
+export const pillars = (num_pill, dist, width) => {
+  const totalWidthOfPillars = num_pill * width
+  const totalSpaceBetweenPillarsInCm = (num_pill - 1) * dist * 100
+  const widthOfFirstAndLastPillar = width * 2
+  return Math.max((totalWidthOfPillars + totalSpaceBetweenPillarsInCm) - widthOfFirstAndLastPillar, 0)
 }

--- a/src/pillars.test.js
+++ b/src/pillars.test.js
@@ -10,14 +10,14 @@ import { pillars } from "./pillars";
 // Calculate the distance between the first and the last pillar
 // in centimeters (without the width of the first and last pillar).
 
-describe("Pillars tests", function() {
-  it("Testing for number of pillars: 1, distance: 10 m and width: 10 cm", function() {
-    expect(pillars(1, 10, 10), 0);
+describe("Pillars tests", function () {
+  it("Testing for number of pillars: 1, distance: 10 m and width: 10 cm", function () {
+    expect(pillars(1, 10, 10)).toEqual(0);
   });
-  it("Testing for number of pillars: 2, distance: 20 m and width: 25 cm", function() {
-    expect(pillars(2, 20, 25), 2000);
+  it("Testing for number of pillars: 2, distance: 20 m and width: 25 cm", function () {
+    expect(pillars(2, 20, 25)).toEqual(2000);
   });
-  it("Testing for number of pillars: 11, distance: 15 m and width: 30 cm", function() {
-    expect(pillars(11, 15, 30), 15270);
+  it("Testing for number of pillars: 11, distance: 15 m and width: 30 cm", function () {
+    expect(pillars(11, 15, 30)).toEqual(15270);
   });
 });


### PR DESCRIPTION
I had to fix the invalid syntax of the test function for the kata i implemented. That's why the list item for "I didn't modify any test case" is unchecked.

## Details
**Link to the issue:** [#133](https://github.com/rgehan/hacktoberfest-2k18-katas/issues/133)

**Name of the function you implemented**: pillars

**Name of the function you added test cases for**: countCodeLines

## Checklist (won't be merged if they are not all ticked)
- [x] I have asked for this issue, and was assigned it
- [x] I have properly filled the "Details" section above  :arrow_up:
- [] I didn't modify any test case  :red_circle:
- [x] I have implemented the function and all its tests pass  :white_check_mark:
- [x] I have added a new test case for someone to implement  :new:
- [x] I have created an issue for my new test case  :speak_no_evil:
- [x] I've :star: the repository (or not, all up to you)
- [x] And more importantly, I've had fun! :beer:
