### PR TITLE
Fix test cases for humanReadableDuration (#1037)

### DIFF
--- a/src/humanReadableDuration.test.js
+++ b/src/humanReadableDuration.test.js
@@ -36,10 +36,10 @@ describe("humanReadableDuration", () => {
   });
 
   it("humanReadableDuration handles invalid input", () => {
-    expect(humanReadableDuration()).toThrow();
-    expect(humanReadableDuration("test")).toThrow();
-    expect(humanReadableDuration(123.456)).toThrow();
-    expect(humanReadableDuration(-987)).toThrow();
-    expect(humanReadableDuration(false)).toThrow();
+    expect(() => humanReadableDuration()).toThrow();
+    expect(() => humanReadableDuration("test")).toThrow();
+    expect(() => humanReadableDuration(123.456)).toThrow();
+    expect(() => humanReadableDuration(-987)).toThrow();
+    expect(() => humanReadableDuration(false)).toThrow();
   });
 });


### PR DESCRIPTION
@rgehan unfortunately I've messed up the test cases for humanReadableDuration kata (#1037) - this should fix it. Sorry!