### PR TITLE
sortByOneBitCount test fix

### DIFF
--- a/src/sortByOneBitCount.test.js
+++ b/src/sortByOneBitCount.test.js
@@ -2,19 +2,19 @@ import { sortByOneBitCount } from './sortByOneBitCount';
 
 describe('sortByOneBitCount', () => {
   it('sorts an array of numbers by their 1 bit count ascending', () => {
-    expect(sortByOneBitCount([1, 2, 3, 4, 5, 6])).toBe([1, 2, 4, 3, 5, 6]);
-    expect(sortByOneBitCount([8, 7, 6, 5, 4, 3, 2, 1])).toBe([8, 4, 2, 1, 6, 5, 3, 7]);
+    expect(sortByOneBitCount([1, 2, 3, 4, 5, 6])).toEqual([1, 2, 4, 3, 5, 6]);
+    expect(sortByOneBitCount([8, 7, 6, 5, 4, 3, 2, 1])).toEqual([8, 4, 2, 1, 6, 5, 3, 7]);
   });
 
   it('removes anything that is not a Number', () => {
-    expect(sortByOneBitCount([1, null, 3, '4', 5, 'six'])).toBe([1, 3, 5]);
+    expect(sortByOneBitCount([1, null, 3, '4', 5, 'six'])).toEqual([1, 3, 5]);
   });
 
   it('handles empty arrays', () => {
-    expect(sortByOneBitCount([])).toBe([]);
+    expect(sortByOneBitCount([])).toEqual([]);
   });
 
   it('handles non Array arguments as empty arrays', () => {
-    expect(sortByOneBitCount('anything')).toBe([]);
+    expect(sortByOneBitCount('anything')).toEqual([]);
   });
 });


### PR DESCRIPTION
A fix for the test provided for the sortByOneBitCount function

## Details
**Issue you fixed:**  #1020

**Issue you added:**  #1024

**Name of the function you implemented**: createUnionSet

**Name of the function you added test cases for**: sortByOneBitCount


## Checklist (won't be merged if they are not all ticked)
- [+] I have asked for this issue, and was assigned it
- [+] I have properly filled the "Details" section above  :arrow_up:
- [+] I didn't modify any test case  :red_circle:
- [+] I have implemented the function and all its tests pass  :white_check_mark:
- [+] I have added a new test case for someone to implement  :new:
- [+] I have created an issue for my new test case  :speak_no_evil:
- [+] I've :star: the repository (or not, all up to you)
- [+] And more importantly, I've had fun! :beer:
