### PR TITLE
Fix test case

### DIFF
--- a/src/squarePyramidArea.test.js
+++ b/src/squarePyramidArea.test.js
@@ -1,34 +1,15 @@
 import { squarePyramidArea } from './squarePyramidArea';
 
-/*
- * Example of the assertions you can use for your tests:
- *
- * - Testing equality between the function's output and a constant:
- * expect(squarePyramidArea()).toEqual(123);
- *
- * - Testing that the function returns null:
- * expect(squarePyramidArea()).toBeNull();
- *
- * - Testing that the function returns a falsy value (eg. false, 0, "")
- * expect(squarePyramidArea()).toBeFalsy();
- *
- * - Testing that the function returns a truthy value (eg. true, 1, "abc")
- * expect(squarePyramidArea()).toBeTruthy();
- *
- * - Testing that the function throws
- * expect(() => { squarePyramidArea(); }).toThrow();
- */
-
 describe('squarePyramidArea', () => {
-  it('squarePyramidArea does this thing...', () => {
-    // TODO Your own assertion here
+  it('Height: 4 units, Edge of Square: 6 units should have the area of 96 units', () => {
+    expect(squarePyramidArea(4, 6)).toBe(96);
   });
 
-  it('squarePyramidArea does that other thing...', () => {
-    // TODO Your own assertion here
+  it('Should throw error if there is no height', () => {
+    expect(() => squarePyramidArea(4)).toThrow();
   });
 
-  it('squarePyramidArea does a very cool thing...', () => {
-    // TODO Your own assertion here
+  it('Should throw error if there is no edge', () => {
+    expect(() => squarePyramidArea(null, 6)).toThrow();
   });
 });

--- a/src/takeRight.test.js
+++ b/src/takeRight.test.js
@@ -33,14 +33,8 @@ describe('takeRight', () => {
     });
 
     it('takeRight correctly...', () => {
-        expect(() => {
-            takeRight([1, 3, 5, 7])
-        }).toEqual([7]);
-        expect(() => {
-            takeRight([2, 4, 6, 8, 10], 2)
-        }).toEqual([8, 10]);
-        expect(() => {
-            takeRight('hello',3)
-        }).toEqual('llo');
+        expect(takeRight([1, 3, 5, 7])).toEqual([7]);
+        expect(takeRight([2, 4, 6, 8, 10], 2)).toEqual([8, 10]);
+        expect(takeRight('hello', 3)).toEqual('llo');
     });
 });


### PR DESCRIPTION
## Fix test cases for takeRight

The test cases that were not expected to throw an error, was written in functions. They would never pass because they were expected to be values, not functions.